### PR TITLE
Clamp speeds to minimum of 0.0f

### DIFF
--- a/treadmill_driver/speed.ino
+++ b/treadmill_driver/speed.ino
@@ -22,7 +22,8 @@ uint8_t speedToPWMSignal(float speed) {
  *
  * https://help.desmos.com/hc/en-us/articles/4406972958733-Regressions */
 float periodToSpeed(uint32_t period) {
-  return 13094.3 / ((float) period + 169.358) - 0.204098;
+  float speed = 13094.3 / ((float) period + 169.358) - 0.204098;
+  return speed < 0 ? 0.0f : speed;
 }
 
 /* The speed sensor is built on a rotating cog wheel with a magnetic sensor.


### PR DESCRIPTION
This pull request makes a minor but important fix to the `periodToSpeed` function in `speed.ino`. The function now ensures that the returned speed value is never negative, returning 0.0 if the computed speed is less than zero.

- Prevents negative speed values in `periodToSpeed` by clamping the minimum return value to 0.0.